### PR TITLE
up compat Polyester

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.jl.mem
 /Manifest.toml
 /docs/build/
+.vscode
 *~
 *#*
 *#*#

--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ Polyester = "f517fe37-dbe3-4b94-8317-1923a5111588"
 
 [compat]
 ForwardDiff = "0.10"
-Polyester = "0.5, 0.6"
+Polyester = "0.5, 0.6, 0.7"
 julia = "1.6"
 
 [extras]

--- a/src/PolyesterForwardDiff.jl
+++ b/src/PolyesterForwardDiff.jl
@@ -48,7 +48,7 @@ function threaded_gradient!(f::F, Δx::AbstractVector, x::AbstractVector, ::Forw
     N = length(x)
     d = cld_fast(N, C)
     r = Ref{eltype(Δx)}()
-    batch((d,min(d,num_threads())), r, Δx, x) do rΔxx,start,stop
+    batch((d,min(d,Threads.nthreads())), r, Δx, x) do rΔxx,start,stop
         evaluate_chunks!(f, rΔxx, start, stop, ForwardDiff.Chunk{C}())
     end
     r[]
@@ -105,7 +105,7 @@ end
 function threaded_jacobian!(f::F, Δx::AbstractArray, x::AbstractArray, ::ForwardDiff.Chunk{C}) where {F,C}
     N = length(x)
     d = cld_fast(N, C)
-    batch((d,min(d,num_threads())), Δx, x) do Δxx,start,stop
+    batch((d,min(d,Threads.nthreads())), Δx, x) do Δxx,start,stop
         evaluate_jacobian_chunks!(f, Δxx, start, stop, ForwardDiff.Chunk{C}())
     end
     return Δx
@@ -162,7 +162,7 @@ end
 function threaded_jacobian!(f!::F, y::AbstractArray, Δx::AbstractArray, x::AbstractArray, ::ForwardDiff.Chunk{C}) where {F,C}
     N = length(x)
     d = cld_fast(N, C)
-    batch((d,min(d,num_threads())), y, Δx, x) do yΔxx,start,stop
+    batch((d,min(d,Threads.nthreads())), y, Δx, x) do yΔxx,start,stop
         evaluate_f_and_jacobian_chunks!(f!, yΔxx, start, stop, ForwardDiff.Chunk{C}())
     end
     Δx

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,7 +11,7 @@ ForwardDiff.gradient!(dxref, f, x, ForwardDiff.GradientConfig(f, x, ForwardDiff.
 @test dx == dxref
 
 dx .= NaN;
-batch((length(x), max(1,num_threads()>>1), 2), dx, x) do (dx,x), start, stop
+batch((length(x), max(1,Threads.nthreads()>>1), 2), dx, x) do (dx,x), start, stop
     PolyesterForwardDiff.threaded_gradient!(f, view(dx, start%Int:stop%Int), view(x, start%Int:stop%Int), ForwardDiff.Chunk(8))
 end;
 @test dx ≈ dxref


### PR DESCRIPTION
- this updates the compat entry for Polyester 
- updates num_threads() to  Threads.nthreads(). In the current state `num_threads` is not defined anywhere. 
- the only [test](https://github.com/lazarusA/PolyesterForwardDiff.jl/blob/e790eb08eb23ca65263672710615526aea22c177/test/runtests.jl#L14) that fails is this one, I don't see how or where to fixed it. 

besides the previous failing test, all other cases work. 